### PR TITLE
Another fix of the edit URL

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,7 +94,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           path: 'docs',
-          editUrl: 'https://github.com/consento-org/consento-org.github.io/tree/main/docs',
+          editUrl: 'https://github.com/consento-org/consento-org.github.io/tree/main',
           routeBasePath: 'docs',
           remarkPlugins: [],
           rehypePlugins: [],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,7 +94,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           path: 'docs',
-          editUrl: 'https://github.com/consento-org/consento-org.github.io/tree/main',
+          editUrl: 'https://github.com/consento-org/consento-org.github.io/edit/main/',
           routeBasePath: 'docs',
           remarkPlugins: [],
           rehypePlugins: [],


### PR DESCRIPTION
Unfortunately the previous fix of the edit URL was not correct, because there is also a setting for the `docs` base path.